### PR TITLE
Fix deprecation warning.

### DIFF
--- a/editorsnotes/settings.py
+++ b/editorsnotes/settings.py
@@ -20,8 +20,8 @@ MEDIA_URL = '/media/'
 ADMIN_MEDIA_PREFIX = '/django_admin_media/'
 
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (


### PR DESCRIPTION
Django 1.3 changed the way template loaders are configured.
