### PR TITLE
Strip punctuation from search queries

### DIFF
--- a/editorsnotes/templates/base.html
+++ b/editorsnotes/templates/base.html
@@ -37,7 +37,7 @@
         <div id="searchform">
           <form action="/search/" method="get" class="inline">
             <div id="searchinput">
-              <input type="text" class="text" name="q"/>
+              <input type="text" class="text" name="q" value="{{ query }}"/>
             </div>
             <div id="searchbutton">
               <button type="submit">Search</button>


### PR DESCRIPTION
...except for colons which we preserve to enable searching for microfilm locations.
