### PR TITLE
Update invitation process for our own User model

### DIFF
--- a/editorsnotes/admin_custom/forms/projects.py
+++ b/editorsnotes/admin_custom/forms/projects.py
@@ -5,13 +5,23 @@ from django.forms.models import (
 
 from editorsnotes.main.models import User, Project, ProjectInvitation
 
+class ProjectRoleField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.role.title()
+
 def make_project_invitation_formset(project):
+    """
+    Create a project invitation formset for a project
+
+    Cannot be done by a simple modelformset_factory because we need to create
+    the Form and FormSet on the fly to take into account existing project
+    invitations.
+    """
+
     if not isinstance(project, Project):
         raise ValueError('{} is not a project.'.format(project))
 
-    project_invitations = ProjectInvitation.objects\
-            .select_related('project')\
-            .filter(project__id=project.id)
+    project_invitations = ProjectInvitation.objects.filter(project_id=project.id)
 
     class ProjectInvitationFormSet(BaseModelFormSet):
         def __init__(self, *args, **kwargs):
@@ -19,27 +29,42 @@ def make_project_invitation_formset(project):
             super(ProjectInvitationFormSet, self).__init__(*args, **kwargs)
 
     class ProjectInvitationForm(ModelForm):
+        project_role = ProjectRoleField(queryset=project.roles.all())
         class Meta:
             model = ProjectInvitation
-            fields = ('email', 'role',)
+            fields = ('email', 'project_role',)
         def __init__(self, *args, **kwargs):
             super(ProjectInvitationForm, self).__init__(*args, **kwargs)
             self.fields['email'].widget.attrs['placeholder'] = 'Email to invite'
         def clean_email(self):
+            "Make sure email is unique for this project"
             data = self.cleaned_data['email']
             user = User.objects.filter(email=data)
+
+            # Check if there are multiple users with this email address. If
+            # there are, fail. In practice, there's no way this should actually
+            # happen.
             if user.count() > 1:
                 msg = 'Multiple users with this email address.'
                 raise forms.ValidationError(msg)
-            elif user.count() == 1 and user[0].get_profile().affiliation == project:
-                msg = 'User with email {} already in project'.format(data)
+
+            # Next, check if there is a user with this email already in the
+            # project, and raise an error if there is.
+            elif user.count() == 1 and project in user.get().get_affiliated_projects():
+                msg = 'User with email {} already in project.'.format(data)
                 raise forms.ValidationError(msg)
+
+            # Next, check if there's already an invitation for this email
+            # address.
+            # TODO: Really, this should be a unique constraint on the model.
             existing_invite = ProjectInvitation.objects.filter(
-                email=data, project=project)
+                email=data, project_id=project.id)
             if not self.instance.id and existing_invite.count():
                 msg = 'User with email {} already invited.'.format(data)
                 raise forms.ValidationError(msg)
+
             return data
+
     return modelformset_factory(
         ProjectInvitation,
         formset=ProjectInvitationFormSet,
@@ -48,7 +73,6 @@ def make_project_invitation_formset(project):
         extra=1
     )
 
-
 def make_project_roster_formset(project):
     """
     Returns a formset for editing project roles.
@@ -56,10 +80,7 @@ def make_project_roster_formset(project):
     if not isinstance(project, Project):
         raise ValueError('{} is not a project.'.format(project))
 
-    project_roster = User.objects\
-            .select_related('userprofile')\
-            .filter(userprofile__affiliation=project)\
-            .order_by('-last_login')
+    project_roster = project.members.order_by('-last_login')
 
     class ProjectRosterFormSet(BaseModelFormSet):
         def __init__(self, *args, **kwargs):
@@ -67,18 +88,17 @@ def make_project_roster_formset(project):
             super(ProjectRosterFormSet, self).__init__(*args, **kwargs)
 
     class ProjectMemberForm(ModelForm):
-        project_role = forms.ChoiceField(choices=('fixme', 'fixme',))
+        project_role = ProjectRoleField(queryset=project.roles.all())
         class Meta:
             model = User
         def __init__(self, *args, **kwargs):
             super(ProjectMemberForm, self).__init__(*args, **kwargs)
             if not self.instance.pk:
                 return
-            profile = self.instance.get_profile()
-            self.initial['project_role'] = profile.get_project_role(project)
+            self.initial['project_role'] = project.get_role_for(self.instance)
         def save(self, commit=True):
             user = self.instance
-            existing_role = user.get_profile().get_project_role(project)
+            existing_role = project.get_role_for(user)
             if existing_role != self.cleaned_data['project_role']:
                 old_role = user.groups.get(name__startswith='{}_'.format(
                     project.slug))

--- a/editorsnotes/admin_custom/templates/project_roster.html
+++ b/editorsnotes/admin_custom/templates/project_roster.html
@@ -83,17 +83,15 @@
       </tr>
     </thead>
     <tbody>
-      {% for profile, role in roster %}
-      {% with user=profile.user %}
+      {% for user, role in roster %}
       <tr id="project-user-{{ user.id }}">
-        <td>{{ profile.as_text }}</td>
+        <td>{{ user.as_text }}</td>
         <td>{{ user.email }}</td>
         <td class="project-user-role">{{ role|title }}</td>
         <td>{{ user.date_joined|date:"M j, Y" }}</td>
         <td>{{ user.last_login|date:"M j, Y" }}</td>
         <td>{{ user.is_active }}</td>
       </tr>
-      {% endwith %}
       {% endfor %}
     </tbody>
   </table>
@@ -118,12 +116,14 @@
       {{ form.DELETE.as_hidden }}
       {% if form.instance.id %}
       Invited {{ form.instance.created|date:"F d, Y" }}: 
-      {{ form.email.value }} ({{ form.role.value }})
-      {{ form.email.as_hidden }} {{ form.role.as_hidden }}
+      {{ form.email.value }}
+      {{ form.email.as_hidden }} {{ form.project_role.as_hidden }}
       {% else %}
       <br />
+      <label for="{{ form.email.auto_id }}">Email</label>
       {{ form.email }}
-      {{ form.role }}
+      <label for="{{ form.project_role.auto_id }}">Project Role</label>
+      {{ form.project_role }}
       {% endif %}
       {% if form.instance.id %}
       <a href="#" class="remove-project-invitation">

--- a/editorsnotes/main/migrations/0119_remove_project_invitations.py
+++ b/editorsnotes/main/migrations/0119_remove_project_invitations.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Remember to use orm['appname.ModelName'] rather than "from appname.models..."
+        orm['main.ProjectInvitation'].objects.all().delete()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djotero.cachedarchive': {
+            'Meta': {'object_name': 'CachedArchive'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {})
+        },
+        u'djotero.cachedcreator': {
+            'Meta': {'object_name': 'CachedCreator'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {})
+        },
+        u'djotero.zoterolink': {
+            'Meta': {'object_name': 'ZoteroLink'},
+            'cached_archive': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djotero.CachedArchive']", 'null': 'True', 'blank': 'True'}),
+            'cached_creator': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['djotero.CachedCreator']", 'null': 'True', 'blank': 'True'}),
+            'date_information': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_synced': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {}),
+            'zotero_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'licensing.license': {
+            'Meta': {'object_name': 'License'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"}),
+            'symbols': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'url': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        'main.alternatename': {
+            'Meta': {'unique_together': "(('topic', 'name'),)", 'object_name': 'AlternateName'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_alternatename_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alternate_names'", 'to': "orm['main.Topic']"})
+        },
+        'main.citation': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'Citation'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_citation_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'citations'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_citation_set'", 'to': "orm['main.User']"}),
+            'notes': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'ordering': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.citationns': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'CitationNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Document']"}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.document': {
+            'Meta': {'ordering': "['ordering', 'import_id']", 'object_name': 'Document'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'parts'", 'null': 'True', 'to': "orm['main.Document']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_document_set'", 'to': "orm['main.User']"}),
+            'description': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'edtf_date': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'default': "'English'", 'max_length': '32'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_document_set'", 'to': "orm['main.User']"}),
+            'ordering': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'documents'", 'to': "orm['main.Project']"}),
+            'zotero_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'zotero_link': ('django.db.models.fields.related.OneToOneField', [], {'blank': 'True', 'related_name': "'zotero_item'", 'unique': 'True', 'null': 'True', 'to': u"orm['djotero.ZoteroLink']"})
+        },
+        'main.documentlink': {
+            'Meta': {'object_name': 'DocumentLink'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_documentlink_set'", 'to': "orm['main.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'main.documentmetadata': {
+            'Meta': {'unique_together': "(('document', 'key'),)", 'object_name': 'DocumentMetadata'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_documentmetadata_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'metadata'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'main.featureditem': {
+            'Meta': {'object_name': 'FeaturedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_featureditem_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Project']"})
+        },
+        'main.footnote': {
+            'Meta': {'object_name': 'Footnote'},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_footnote_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_footnote_set'", 'to': "orm['main.User']"}),
+            'transcript': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'footnotes'", 'to': "orm['main.Transcript']"})
+        },
+        'main.legacytopic': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'LegacyTopic'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.TopicNode']", 'null': 'True', 'blank': 'True'}),
+            'preferred_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'", 'db_index': 'True'})
+        },
+        'main.note': {
+            'Meta': {'ordering': "['-last_updated']", 'object_name': 'Note'},
+            'assigned_users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['main.User']", 'null': 'True', 'blank': 'True'}),
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_note_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_note_set'", 'to': "orm['main.User']"}),
+            'license': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['licensing.License']", 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'notes'", 'to': "orm['main.Project']"}),
+            'sections_counter': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'1'", 'max_length': '1'}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"})
+        },
+        'main.notereferencens': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'NoteReferenceNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'note_reference': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Note']"}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.notesection': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'unique_together': "(['note', 'note_section_id'],)", 'object_name': 'NoteSection'},
+            '_section_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_notesection_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_notesection_set'", 'to': "orm['main.User']"}),
+            'note': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sections'", 'to': "orm['main.Note']"}),
+            'note_section_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.project': {
+            'Meta': {'object_name': 'Project'},
+            'default_license': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['licensing.License']"}),
+            'description': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': "'80'"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'main.projectinvitation': {
+            'Meta': {'object_name': 'ProjectInvitation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_projectinvitation_set'", 'to': "orm['main.User']"}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        'main.projectrole': {
+            'Meta': {'unique_together': "(('project', 'role'),)", 'object_name': 'ProjectRole'},
+            'group': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.Group']", 'unique': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_super_role': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'roles'", 'to': "orm['main.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '40'})
+        },
+        'main.scan': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'Scan'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_scan_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'scans'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'ordering': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.textns': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'TextNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.topic': {
+            'Meta': {'unique_together': "(('project', 'preferred_name'),)", 'object_name': 'Topic'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topic_set'", 'to': "orm['main.User']"}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_topic_set'", 'to': "orm['main.User']"}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Topic']", 'null': 'True', 'blank': 'True'}),
+            'preferred_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics'", 'to': "orm['main.Project']"}),
+            'summary': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'topic_node': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'project_topics'", 'to': "orm['main.TopicNode']"})
+        },
+        'main.topicassignment': {
+            'Meta': {'unique_together': "(('content_type', 'object_id', 'topic'),)", 'object_name': 'TopicAssignment'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topicassignment_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'assignments'", 'null': 'True', 'to': "orm['main.Topic']"})
+        },
+        'main.topicnode': {
+            'Meta': {'object_name': 'TopicNode'},
+            '_preferred_name': ('django.db.models.fields.CharField', [], {'max_length': "'200'"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topicnode_set'", 'to': "orm['main.User']"}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_topicnode_set'", 'to': "orm['main.User']"}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.TopicNode']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'})
+        },
+        'main.transcript': {
+            'Meta': {'object_name': 'Transcript'},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_transcript_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'_transcript'", 'unique': 'True', 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_transcript_set'", 'to': "orm['main.User']"})
+        },
+        'main.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'zotero_key': ('django.db.models.fields.CharField', [], {'max_length': "'24'", 'null': 'True', 'blank': 'True'}),
+            'zotero_uid': ('django.db.models.fields.CharField', [], {'max_length': "'6'", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['main']
+    symmetrical = True

--- a/editorsnotes/main/migrations/0120_auto__del_field_projectinvitation_role__add_field_projectinvitation_pr.py
+++ b/editorsnotes/main/migrations/0120_auto__del_field_projectinvitation_role__add_field_projectinvitation_pr.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'ProjectInvitation.role'
+        db.delete_column(u'main_projectinvitation', 'role')
+
+        # Adding field 'ProjectInvitation.project_role'
+        db.add_column(u'main_projectinvitation', 'project_role',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['main.ProjectRole']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'ProjectInvitation.role'
+        raise RuntimeError("Cannot reverse this migration. 'ProjectInvitation.role' and its values cannot be restored.")
+        # Deleting field 'ProjectInvitation.project_role'
+        db.delete_column(u'main_projectinvitation', 'project_role_id')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'djotero.cachedarchive': {
+            'Meta': {'object_name': 'CachedArchive'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {})
+        },
+        u'djotero.cachedcreator': {
+            'Meta': {'object_name': 'CachedCreator'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {})
+        },
+        u'djotero.zoterolink': {
+            'Meta': {'object_name': 'ZoteroLink'},
+            'cached_archive': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['djotero.CachedArchive']", 'null': 'True', 'blank': 'True'}),
+            'cached_creator': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['djotero.CachedCreator']", 'null': 'True', 'blank': 'True'}),
+            'date_information': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_synced': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {}),
+            'zotero_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'licensing.license': {
+            'Meta': {'object_name': 'License'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"}),
+            'symbols': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'url': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'})
+        },
+        'main.alternatename': {
+            'Meta': {'unique_together': "(('topic', 'name'),)", 'object_name': 'AlternateName'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_alternatename_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'alternate_names'", 'to': "orm['main.Topic']"})
+        },
+        'main.citation': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'Citation'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_citation_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'citations'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_citation_set'", 'to': "orm['main.User']"}),
+            'notes': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'ordering': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.citationns': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'CitationNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Document']"}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.document': {
+            'Meta': {'ordering': "['ordering', 'import_id']", 'object_name': 'Document'},
+            'collection': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'parts'", 'null': 'True', 'to': "orm['main.Document']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_document_set'", 'to': "orm['main.User']"}),
+            'description': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'edtf_date': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '64', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'default': "'English'", 'max_length': '32'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_document_set'", 'to': "orm['main.User']"}),
+            'ordering': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'documents'", 'to': "orm['main.Project']"}),
+            'zotero_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'zotero_link': ('django.db.models.fields.related.OneToOneField', [], {'blank': 'True', 'related_name': "'zotero_item'", 'unique': 'True', 'null': 'True', 'to': u"orm['djotero.ZoteroLink']"})
+        },
+        'main.documentlink': {
+            'Meta': {'object_name': 'DocumentLink'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_documentlink_set'", 'to': "orm['main.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'main.documentmetadata': {
+            'Meta': {'unique_together': "(('document', 'key'),)", 'object_name': 'DocumentMetadata'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_documentmetadata_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'metadata'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'value': ('django.db.models.fields.TextField', [], {})
+        },
+        'main.featureditem': {
+            'Meta': {'object_name': 'FeaturedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_featureditem_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Project']"})
+        },
+        'main.footnote': {
+            'Meta': {'object_name': 'Footnote'},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_footnote_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_footnote_set'", 'to': "orm['main.User']"}),
+            'transcript': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'footnotes'", 'to': "orm['main.Transcript']"})
+        },
+        'main.legacytopic': {
+            'Meta': {'ordering': "['slug']", 'object_name': 'LegacyTopic'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.TopicNode']", 'null': 'True', 'blank': 'True'}),
+            'preferred_name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'", 'db_index': 'True'})
+        },
+        'main.note': {
+            'Meta': {'ordering': "['-last_updated']", 'object_name': 'Note'},
+            'assigned_users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['main.User']", 'null': 'True', 'blank': 'True'}),
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_note_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_note_set'", 'to': "orm['main.User']"}),
+            'license': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['licensing.License']", 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'notes'", 'to': "orm['main.Project']"}),
+            'sections_counter': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'1'", 'max_length': '1'}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': "'80'"})
+        },
+        'main.notereferencens': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'NoteReferenceNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'note_reference': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Note']"}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.notesection': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'unique_together': "(['note', 'note_section_id'],)", 'object_name': 'NoteSection'},
+            '_section_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_notesection_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_notesection_set'", 'to': "orm['main.User']"}),
+            'note': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sections'", 'to': "orm['main.Note']"}),
+            'note_section_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.project': {
+            'Meta': {'object_name': 'Project'},
+            'default_license': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['licensing.License']"}),
+            'description': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': "'80'"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'main.projectinvitation': {
+            'Meta': {'object_name': 'ProjectInvitation'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_projectinvitation_set'", 'to': "orm['main.User']"}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Project']"}),
+            'project_role': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.ProjectRole']"})
+        },
+        'main.projectrole': {
+            'Meta': {'unique_together': "(('project', 'role'),)", 'object_name': 'ProjectRole'},
+            'group': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.Group']", 'unique': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_super_role': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'roles'", 'to': "orm['main.Project']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '40'})
+        },
+        'main.scan': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'Scan'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_scan_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'scans'", 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'ordering': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'main.textns': {
+            'Meta': {'ordering': "['ordering', 'note_section_id']", 'object_name': 'TextNS', '_ormbases': ['main.NoteSection']},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            u'notesection_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['main.NoteSection']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'main.topic': {
+            'Meta': {'unique_together': "(('project', 'preferred_name'),)", 'object_name': 'Topic'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topic_set'", 'to': "orm['main.User']"}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_topic_set'", 'to': "orm['main.User']"}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.Topic']", 'null': 'True', 'blank': 'True'}),
+            'preferred_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics'", 'to': "orm['main.Project']"}),
+            'summary': ('editorsnotes.main.fields.XHTMLField', [], {'null': 'True', 'blank': 'True'}),
+            'topic_node': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'project_topics'", 'to': "orm['main.TopicNode']"})
+        },
+        'main.topicassignment': {
+            'Meta': {'unique_together': "(('content_type', 'object_id', 'topic'),)", 'object_name': 'TopicAssignment'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topicassignment_set'", 'to': "orm['main.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'assignments'", 'null': 'True', 'to': "orm['main.Topic']"})
+        },
+        'main.topicnode': {
+            'Meta': {'object_name': 'TopicNode'},
+            '_preferred_name': ('django.db.models.fields.CharField', [], {'max_length': "'200'"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_topicnode_set'", 'to': "orm['main.User']"}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_topicnode_set'", 'to': "orm['main.User']"}),
+            'merged_into': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['main.TopicNode']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'})
+        },
+        'main.transcript': {
+            'Meta': {'object_name': 'Transcript'},
+            'content': ('editorsnotes.main.fields.XHTMLField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_transcript_set'", 'to': "orm['main.User']"}),
+            'document': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'_transcript'", 'unique': 'True', 'to': "orm['main.Document']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'last_updater': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'last_to_update_transcript_set'", 'to': "orm['main.User']"})
+        },
+        'main.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'zotero_key': ('django.db.models.fields.CharField', [], {'max_length': "'24'", 'null': 'True', 'blank': 'True'}),
+            'zotero_uid': ('django.db.models.fields.CharField', [], {'max_length': "'6'", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['main']

--- a/editorsnotes/main/models/auth.py
+++ b/editorsnotes/main/models/auth.py
@@ -147,6 +147,9 @@ class Project(models.Model, URLAccessible, ProjectPermissionsMixin):
     def members(self):
         role_groups = self.roles.values_list('group_id', flat=True)
         return User.objects.filter(groups__in=role_groups)
+    def members_by_role(self):
+        roles = ProjectRole.objects.for_project(self).select_related('user')
+        return
     def get_role_for(self, user):
         qs = self.roles.filter(group__user=user)
         return qs.get() if qs.exists() else None
@@ -265,7 +268,7 @@ class ProjectInvitation(CreationMetadata):
         app_label = 'main'
     project = models.ForeignKey(Project)
     email = models.EmailField()
-    role = models.CharField(max_length=10)
+    project_role = models.ForeignKey(ProjectRole)
     def __unicode__(self):
         return '{} ({})'.format(self.email, self.project.name)
 

--- a/editorsnotes/main/templates/project.html
+++ b/editorsnotes/main/templates/project.html
@@ -29,7 +29,7 @@
     {% endif %}
 
     {% if can_change_project %}
-    <a class="btn" href="{% url "project_edit_view" project_id=project.id %}?return_to={{ request.path }}">
+    <a class="btn" href="{% url "project_edit_view" project_slug=project.slug %}?return_to={{ request.path }}">
       <i class="icon-edit"></i>
       Edit project description
     </a>


### PR DESCRIPTION
This was something that I forgot to do after substituting our own custom
User model in 95e0f72. The implementation of project member invitatioins
contained lots of references to UserProfile models and "old-style"
project membership attributes/methods. This updates the forms, views,
and template for project roster editing to reflect the new reality.

TODO still: make custom project roles with fine-grained permissions
(important)
