### PR TITLE
Tweak elasticsearch index naming

### DIFF
--- a/editorsnotes/example-settings_local.py
+++ b/editorsnotes/example-settings_local.py
@@ -11,14 +11,19 @@ POSTGRES_DB = {
     'PORT': ''
 }
 
+
 ELASTICSEARCH_ENABLED = True
-ELASTICSEARCH_INDEX_NAME = 'editorsnotes'
-ELASTICSEARCH_URLS = 'http://127.0.0.1:9200'
+
+# Each ElasticSearch index created will be prefixed with this string.
+ELASTICSEARCH_PREFIX = 'editorsnotes'
+
 # As defined in pyelasticsearch, ELASTICSEARCH_URLS should be:
 #
 # A URL or iterable of URLs of ES nodes. These are full URLs with port numbers,
 # like ``http://elasticsearch.example.com:9200``.
 #
+ELASTICSEARCH_URLS = 'http://127.0.0.1:9200'
+
 
 SITE_URL = '127.0.0.1'
 

--- a/editorsnotes/search/index.py
+++ b/editorsnotes/search/index.py
@@ -22,11 +22,10 @@ class OrderedResponseElasticSearch(ElasticSearch):
         return json_response
 
 class ElasticSearchIndex(object):
-    def __init__(self, name=None):
-        if not self.name:
-            if name is None:
-                raise NotImplementedError('Must provide name for index.')
-            self.name = name
+    def __init__(self):
+        if not hasattr(self, 'get_name'):
+            raise NotImplementedError('Must implement get_name method')
+        self.name = self.get_name()
         self.es = OrderedResponseElasticSearch(settings.ELASTICSEARCH_URLS)
         if not self.exists():
             self.create()
@@ -48,10 +47,12 @@ class ElasticSearchIndex(object):
 
 
 class ENIndex(ElasticSearchIndex):
-    name = settings.ELASTICSEARCH_INDEX_NAME
     def __init__(self):
         super(ENIndex, self).__init__()
         self.document_types = {}
+
+    def get_name(self):
+        return settings.ELASTICSEARCH_PREFIX + '-items'
 
     def get_settings(self):
         return {
@@ -133,7 +134,8 @@ VERSION_ACTIONS = {
 }
 
 class ActivityIndex(ElasticSearchIndex):
-    name = 'editorsnotes-activitylog'
+    def get_name(self):
+        return settings.ELASTICSEARCH_PREFIX + '-activitylog'
     def get_activity_for(self, entity, size=25, **kwargs):
         query = { 'query': {}, 'sort': { 'data.time': { 'order': 'desc' } } }
         if isinstance(entity, User):

--- a/editorsnotes/testrunner.py
+++ b/editorsnotes/testrunner.py
@@ -8,22 +8,30 @@ class CustomTestSuiteRunner(DjangoTestSuiteRunner):
     def setup_test_environment(self, **kwargs):
         super(CustomTestSuiteRunner, self).setup_test_environment(**kwargs)
 
-        test_index_name = 'test-' + settings.ELASTICSEARCH_INDEX_NAME
+        test_index_prefix = settings.ELASTICSEARCH_PREFIX + '-test'
+        settings.ELASTICSEARCH_PREFIX = test_index_prefix
 
-        from editorsnotes.search import en_index
-        en_index.name = settings.ELASTICSEARCH_INDEX_NAME = test_index_name
+        from editorsnotes.search import en_index, activity_index
+
+        en_index.name = en_index.get_name()
+        activity_index.name = activity_index.get_name()
 
         for doctype in en_index.document_types.values():
-            doctype.index_name = test_index_name
+            doctype.index_name = en_index.name
 
         try:
             en_index.create()
+            activity_index.create()
         except IndexAlreadyExistsError:
             en_index.delete()
             en_index.create()
+            activity_index.delete()
+            activity_index.create()
 
     def teardown_test_environment(self, **kwargs):
         super(CustomTestSuiteRunner, self).teardown_test_environment(**kwargs)
 
-        from editorsnotes.search import en_index
-        z = en_index.delete()
+        from editorsnotes.search import en_index, activity_index
+        en_index.delete()
+        activity_index.delete()
+


### PR DESCRIPTION
Define a prefix now, instead of one main one, since we now have multiple
indexes
