### PR TITLE
Ignore sort order for activity index if unmapped

### DIFF
--- a/editorsnotes/search/index.py
+++ b/editorsnotes/search/index.py
@@ -137,7 +137,10 @@ class ActivityIndex(ElasticSearchIndex):
     def get_name(self):
         return settings.ELASTICSEARCH_PREFIX + '-activitylog'
     def get_activity_for(self, entity, size=25, **kwargs):
-        query = { 'query': {}, 'sort': { 'data.time': { 'order': 'desc' } } }
+        query = {
+            'query': {},
+            'sort': {'data.time': { 'order': 'desc', 'ignore_unmapped': True }}
+        }
         if isinstance(entity, User):
             query['query']['match'] = { 'data.user': entity.username }
         elif isinstance(entity, Project):


### PR DESCRIPTION
This prevents an error from being raised on a fresh deployment if no
items have been yet added to the activity index
